### PR TITLE
Add dynamic ASN.1 parser with XML decoder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Senora ASN Editor
 
-Senora is a simple web interface for viewing and editing ASN.1 data.
+Senora provides a web interface for decoding and editing BER encoded CDR files using XML decoder definitions.
 
 ## Installation
 
@@ -18,4 +18,6 @@ Run the Flask application:
 python app.py
 ```
 
-Open your browser to `http://localhost:5000` to use the editor.
+Open your browser to `http://localhost:5000`.
+Upload an XML decoder and a BER CDR file to view and edit the decoded
+content. After editing you can download the modified CDR as a BER file.

--- a/asn1_parser.py
+++ b/asn1_parser.py
@@ -1,0 +1,66 @@
+import xml.etree.ElementTree as ET
+from typing import List, Dict, Tuple
+import asn1tools
+
+TYPE_MAP = {
+    'string': 'OCTET STRING',
+    'octetstring': 'OCTET STRING',
+    'integer': 'INTEGER',
+    'int': 'INTEGER',
+    'boolean': 'BOOLEAN',
+    'bool': 'BOOLEAN'
+}
+
+
+def parse_xml(xml_bytes: bytes) -> List[Dict[str, str]]:
+    """Parse XML decoder and return field definitions."""
+    try:
+        root = ET.fromstring(xml_bytes)
+    except ET.ParseError as exc:
+        raise ValueError(f'Invalid XML: {exc}') from exc
+
+    fields = []
+    for field in root.findall('.//field'):
+        name = field.get('name')
+        tag = field.get('tag') or field.get('id')
+        ftype = field.get('type', 'string')
+        if not name or tag is None:
+            continue
+        fields.append({'name': name, 'tag': tag, 'type': ftype})
+
+    if not fields:
+        raise ValueError('No fields found in XML')
+    return fields
+
+
+def build_asn1_spec(fields: List[Dict[str, str]]) -> str:
+    """Build an ASN.1 specification from parsed fields."""
+    lines = ['CDR DEFINITIONS ::= BEGIN', 'CDR ::= SEQUENCE {']
+    for idx, f in enumerate(fields):
+        asn1_type = TYPE_MAP.get(f['type'].lower(), 'OCTET STRING')
+        comma = ',' if idx < len(fields) - 1 else ''
+        lines.append(f"  {f['name']} [{f['tag']}] {asn1_type}{comma}")
+    lines.append('}')
+    lines.append('END')
+    return '\n'.join(lines)
+
+
+def compile_spec(xml_bytes: bytes) -> Tuple[asn1tools.compiler.AbstractCompiler, str]:
+    """Compile ASN.1 spec from XML and return compiler and spec string."""
+    fields = parse_xml(xml_bytes)
+    spec = build_asn1_spec(fields)
+    compiler = asn1tools.compile_string(spec, 'ber')
+    return compiler, spec
+
+
+def decode_ber(xml_bytes: bytes, ber_bytes: bytes) -> Tuple[Dict, str]:
+    """Decode BER data using XML decoder."""
+    compiler, spec = compile_spec(xml_bytes)
+    decoded = compiler.decode('CDR', ber_bytes)
+    return decoded, spec
+
+
+def encode_ber(spec: str, data: Dict) -> bytes:
+    """Encode data dictionary into BER using provided ASN.1 spec."""
+    compiler = asn1tools.compile_string(spec, 'ber')
+    return compiler.encode('CDR', data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 pyasn1
+asn1tools

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,2 @@
+body { background-color: #f8f9fa; }
+#editor { height: 400px; }

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -2,33 +2,33 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>SENORA ASN Editor – Created by Rosane</title>
+    <title>SENORA ASN Editor</title>
+    <link rel="stylesheet" href="/static/style.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/jsoneditor@9.10.1/dist/jsoneditor.min.css" rel="stylesheet">
-    <style>
-        body { background-color: #f8f9fa; }
-        #editor { height: 400px; }
-        pre.hex-view { background:#f0f0f0; max-height:200px; overflow:auto; }
-    </style>
 </head>
 <body class="p-4">
 <div class="container">
-    <h1 class="mb-4 text-center text-primary">SENORA ASN Editor – by Rosane</h1>
+    <h1 class="mb-4 text-center text-primary">SENORA ASN Editor</h1>
     <form id="uploadForm" enctype="multipart/form-data" class="mb-3">
-        <div class="input-group">
-            <input type="file" name="asnfile" class="form-control" required>
-            <button type="submit" class="btn btn-success">Upload</button>
+        <div class="row g-2">
+            <div class="col">
+                <label class="form-label">XML Decoder</label>
+                <input type="file" name="decoder" class="form-control" required>
+            </div>
+            <div class="col">
+                <label class="form-label">BER CDR</label>
+                <input type="file" name="cdr" class="form-control" required>
+            </div>
+            <div class="col-auto align-self-end">
+                <button type="submit" class="btn btn-success">Upload</button>
+            </div>
         </div>
     </form>
-    <div id="editor" class="border"></div>
+    <div id="editor" class="border" style="height:400px;"></div>
     <div class="mt-3">
         <button id="saveBtn" class="btn btn-primary">Save As</button>
         <button id="resetBtn" class="btn btn-secondary">Reset</button>
-        <button id="toggleHex" class="btn btn-info">Toggle Hex View</button>
-    </div>
-    <div id="hexContainer" class="mt-3" style="display:none;">
-        <h5>Raw Hex</h5>
-        <pre id="hexView" class="hex-view"></pre>
     </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -47,11 +47,12 @@ document.getElementById('uploadForm').addEventListener('submit', function(e){
     const formData = new FormData(this);
     axios.post('/upload', formData)
       .then(res => {
-        originalData = res.data.json;
+        originalData = res.data;
         editor.set(originalData);
-        document.getElementById('hexView').textContent = res.data.hex;
       })
-      .catch(() => alert('Upload failed'));
+      .catch(err => {
+        alert(err.response?.data?.error || 'Upload failed');
+      });
 });
 
 document.getElementById('saveBtn').addEventListener('click', function(){
@@ -65,16 +66,13 @@ document.getElementById('saveBtn').addEventListener('click', function(){
         a.click();
         window.URL.revokeObjectURL(url);
       })
-      .catch(() => alert('Save failed'));
+      .catch(err => {
+        alert(err.response?.data?.error || 'Save failed');
+      });
 });
 
 document.getElementById('resetBtn').addEventListener('click', function(){
     if(originalData) editor.set(originalData);
-});
-
-document.getElementById('toggleHex').addEventListener('click', function(){
-    const hexDiv = document.getElementById('hexContainer');
-    hexDiv.style.display = hexDiv.style.display === 'none' ? 'block' : 'none';
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add asn1_parser module to build ASN.1 specs from XML and encode/decode BER
- rewrite `app.py` to handle XML decoder and CDR uploads
- new web UI in `templates/edit.html`
- add static CSS
- update requirements and README
- ignore `__pycache__`

## Testing
- `python -m compileall -q .`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6889e1b4b070832fae2e6a80b5c1b8fc