### PR TITLE
Fix compile_spec for Huawei XML

### DIFF
--- a/asn1_parser.py
+++ b/asn1_parser.py
@@ -46,9 +46,55 @@ def build_asn1_spec(fields: List[Dict[str, str]]) -> str:
 
 
 def compile_spec(xml_bytes: bytes) -> Tuple[asn1tools.compiler.AbstractCompiler, str]:
-    """Compile ASN.1 spec from XML and return compiler and spec string."""
-    fields = parse_xml(xml_bytes)
-    spec = build_asn1_spec(fields)
+    """Parse Huawei style XML and compile a temporary ASN.1 module."""
+    try:
+        root = ET.fromstring(xml_bytes)
+    except ET.ParseError as exc:
+        raise ValueError(f"Invalid XML: {exc}") from exc
+
+    fields = []
+
+    # Huawei decoder definitions usually group fields under <record> elements.
+    records = root.findall('.//record') or [root]
+    for rec in records:
+        for field in rec.findall('.//field'):
+            name = field.get('name') or field.get('fieldName')
+            tag = field.get('tag') or field.get('id')
+            ftype = field.get('type') or field.get('dataType') or 'OCTET STRING'
+            length = field.get('length') or field.get('len') or field.get('size')
+            if name is None or tag is None:
+                continue
+            try:
+                tag = int(tag, 0)
+            except ValueError:
+                continue
+            fields.append({'name': name, 'tag': tag, 'type': ftype, 'length': length})
+
+    if not fields:
+        raise ValueError("No fields parsed from XML")
+
+    print(f"Parsed {len(fields)} fields: {[f['name'] for f in fields]}")
+
+    lines = ["MyCDR DEFINITIONS ::= BEGIN", "Record ::= SEQUENCE {"]
+    for idx, f in enumerate(fields):
+        asn1_type = TYPE_MAP.get(f['type'].lower(), f['type'].upper())
+        constraint = ''
+        if f['length']:
+            ln = f['length'].replace(' ', '')
+            if '..' in ln:
+                constraint = f"(SIZE({ln}))" if asn1_type == 'OCTET STRING' else f"({ln})"
+            else:
+                constraint = f"(SIZE({ln}))" if asn1_type == 'OCTET STRING' else f"({ln})"
+        line = f"    {f['name']} [{f['tag']}] {asn1_type}"
+        if constraint:
+            line += f" {constraint}"
+        if idx < len(fields) - 1:
+            line += ','
+        lines.append(line)
+    lines.append('}')
+    lines.append('END')
+
+    spec = '\n'.join(lines)
     compiler = asn1tools.compile_string(spec, 'ber')
     return compiler, spec
 


### PR DESCRIPTION
## Summary
- rewrite compile_spec to parse Huawei-style decoder XML
- construct ASN.1 module dynamically from parsed fields
- add message logging of parsed field count and names

## Testing
- `python -m py_compile asn1_parser.py`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6889e54fb7a0832f8bbb59ea331702a9